### PR TITLE
Hide MainActivity's BottomNavigationBar if it's empty

### DIFF
--- a/app/src/main/java/info/frederico/mensaviewer/MainActivity.kt
+++ b/app/src/main/java/info/frederico/mensaviewer/MainActivity.kt
@@ -195,6 +195,9 @@ class MainActivity : AppCompatActivity() {
         var selectedMensas = PreferenceManager.getDefaultSharedPreferences(this).getStringSet(getString(R.string.pref_mensa), resources.getStringArray(R.array.pref_mensa_default).toSet())
         if(selectedMensas.isEmpty()){
             throw NavigationInvalidException()
+        } else {
+            // BottomNavigationBar is hidden by default / if it's empty
+            navigation.visibility = View.VISIBLE
         }
         for (m in selectedMensas) {
             val mensa = Mensa.valueOf(m)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,6 +41,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="0dp"
         android:layout_marginStart="0dp"
+        android:visibility="gone"
         android:background="?android:attr/windowBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION
If accepted, this pull request hides MainActivity's BottomNavigationBar if it's empty. This is helpful since the user might consider the application broken if he sees an empty navbar.